### PR TITLE
Fix backlog appending

### DIFF
--- a/src/spreadsheet/google-sheet.ts
+++ b/src/spreadsheet/google-sheet.ts
@@ -51,7 +51,7 @@ export class GoogleSheet {
       sheets.spreadsheets.values.append({
         auth: this.oAuth2Client,
         spreadsheetId: this.id,
-        range: `${sheetName}!A1:V`,
+        range: `${sheetName}!A1`,
         valueInputOption: "USER_ENTERED",
         resource,
       } as any, (err: any, res: any) => {


### PR DESCRIPTION
Now automated backlog has an issue with shifting a new items to the right:
![Screenshot_20210513_103010](https://user-images.githubusercontent.com/5887312/118093554-4829bc00-b3d6-11eb-86af-886be3efd51b.png)
It's pretty easy to reproduce - just remove the empty row in the end (which is the regular case since script does not append empty row).

I'm not 100% sure about the fix but as far as I tested of my backlog copy, it helps.
According to https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/append 
A1 should be enough:
> The A1 notation of a range to search for a logical table of data. Values are appended after the last row of the table.